### PR TITLE
Emit ISO8601 dateString to Nightscout

### DIFF
--- a/nightscoutlib.py
+++ b/nightscoutlib.py
@@ -159,14 +159,14 @@ class nightscout_uploader(object):
       payload = {
             "device":self.device+data["serial"],
             "type":"sgv",
-            "dateString":date.strftime("%c"),
+            "dateString":date.isoformat(),
             "date":int(date.strftime("%s"))*1000,
             "sgv":sgv,
             "direction":trend_str
          }
-      #print "url: " + url
-      #print "headers: "+json.dumps(self.headers)
-      #print "payload: "+json.dumps(payload)
+      #print("url: " + url)
+      #print("headers: "+json.dumps(self.headers))
+      #print("payload: "+json.dumps(payload))
       
       try:
          #print "Send API request"


### PR DESCRIPTION
The current code on ddguard master creates "dateString" attributes with a time in the future. Using .isoformat fixes this behaviour in my test setup.